### PR TITLE
Adjust DynamoDB resource to support a Range Key

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -46,6 +46,8 @@ module.exports = (argv) => {
         process.stdin.on('keypress', (str, key) => {
           if (key.name === 'i') {
             exec(`open http://localhost:${results.inspector.port}`)
+          } else if (key.name === 'o') {
+            exec(`open https://localnoop.app:${results.devServer.port}`)
           } else if (key.name === 'q') {
             clearInterval(interval)
             done()

--- a/lib/resources/dynamodb.js
+++ b/lib/resources/dynamodb.js
@@ -49,10 +49,13 @@ class DynamodbContainer extends ResourceContainer {
           AWS_SECRET_ACCESS_KEY: '1234567890'
         }
       }
-      const attributeDefinitions = `AttributeName=${this.resource.params.hashKeyName},AttributeType=${this.resource.params.hashKeyType}`
-      const keySchema = `AttributeName=${this.resource.params.hashKeyName},KeyType=HASH`
-      // TODO support Range Keys
-      setupContainer.cmd = ['dynamodb', 'create-table', '--endpoint-url', `http://${this.name}:8000`, '--region', 'local', '--table-name', this.name, '--attribute-definitions', attributeDefinitions, '--key-schema', keySchema, '--provisioned-throughput', 'ReadCapacityUnits=5,WriteCapacityUnits=5']
+      const attributeDefinitions = [`AttributeName=${this.resource.params.hashKeyName},AttributeType=${this.resource.params.hashKeyType}`]
+      const keySchema = [`AttributeName=${this.resource.params.hashKeyName},KeyType=HASH`]
+      if (this.resource.params.rangeKeyName) {
+        attributeDefinitions.push(`AttributeName=${this.resource.params.rangeKeyName},AttributeType=${this.resource.params.rangeKeyType}`)
+        keySchema.push(`AttributeName=${this.resource.params.rangeKeyName},KeyType=RANGE`)
+      }
+      setupContainer.cmd = ['dynamodb', 'create-table', '--endpoint-url', `http://${this.name}:8000`, '--region', 'local', '--table-name', this.name, '--attribute-definitions', ...attributeDefinitions, '--key-schema', ...keySchema, '--provisioned-throughput', 'ReadCapacityUnits=5,WriteCapacityUnits=5']
       setupContainer.start(done)
     })
   }


### PR DESCRIPTION
Added a condition to the `dynamodb.js` file to append commands to create a range key on the db table if appropriate params exist. Tested locally with a Noopfile, and was able to properly assign a range key to a table.